### PR TITLE
docs: add README.md with project overview and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# NovaPay Compliance Reports
+
+A centralized repository for NovaPay's security compliance documentation, audit reports, and remediation plans.
+
+## Overview
+
+This repository contains compliance reports, checklists, and action plans covering NovaPay's regulatory and security posture across multiple frameworks.
+
+## Contents
+
+| Area | Documents |
+|------|-----------|
+| **PCI-DSS** | Gap analysis, compliance checklists, summary reports |
+| **PII & Data Residency** | Residency compliance plans, PII/PCI cross-reference reports |
+| **IAM** | Role permissions audit, compliance checklist, recommendations |
+| **Fraud Detection** | Chargeback analysis, detection protocols, strategy docs |
+| **Incident Response** | IR plan, response playbooks, active IR status reports |
+| **Vulnerability Management** | SQL injection scan reports, remediation checklists |
+| **Vendor Risk** | Vendor risk assessments, follow-up tracking |
+| **AWS Compliance** | AWS compliance actions, summary reports |
+| **Key Management** | Key management policy, compliance checklist |
+| **Network Security** | Zero Trust policy reports, network evidence summaries |
+| **Dependency Audits** | Dependency manifests, vulnerability tracking |
+
+## Directory Structure
+compliance-reports/   → Formal compliance report documents
+evidence/             → Supporting evidence artifacts
+ir/                   → Incident response records
+response_playbooks/   → Runbooks for incident scenarios
+releases/             → Versioned release artifacts
+
+## Contributing
+
+1. Fork the repository
+2. Create a branch: `git checkout -b docs/your-change`
+3. Commit your changes and open a pull request
+
+Please ensure all documents follow the existing Markdown conventions and include accurate dates and version information.
+
+## License
+
+Internal use only — NovaPay confidential compliance documentation.


### PR DESCRIPTION
Closes #447

## What this PR does

Adds a `README.md` to the repository root, which was previously missing (reported in #447).

The README includes:
- A brief overview of the repository's purpose
- A content table mapping each compliance area to its documents
- The directory structure with descriptions
- Basic contributing guidelines
- License/usage note

## Why

Without a README, contributors and reviewers landing on the repo have no context about what the project is, what the documents cover, or how the repo is organized. This is especially important for a compliance-focused repository where clarity matters.

## Changes

- `README.md` — new file, root level

## Notes

No existing files were modified. The README was written based solely on the existing file and folder names in the repo to ensure accuracy.